### PR TITLE
RFC: use Rust edition 2018 and add timer proxy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,11 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 embedded-hal = "0.2.3"
+nb = "0.1.2"
+
+[dependencies.void]
+default-features = false
+version = "1.0.2"
 
 [dev-dependencies]
 embedded-hal-mock = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "shared-bus"
 version = "0.1.4"
 authors = ["Rahix <rahix@rahix.de>"]
+edition = "2018"
 
 description = "Abstraction for sharing a bus between multiple devices."
 homepage = "https://github.com/Rahix/shared-bus"
@@ -13,14 +14,14 @@ categories = ["embedded", "no-std"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-embedded-hal = "0.2.1"
+embedded-hal = "0.2.3"
 
 [dev-dependencies]
-embedded-hal-mock = "0.4.0"
+embedded-hal-mock = "0.7.0"
 
 [dependencies.cortex-m]
 optional = true
-version = "0.5.4"
+version = "0.6.0"
 
 [features]
 std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,8 @@
 #[cfg(feature = "cortexm")]
 use cortex_m;
 use embedded_hal as hal;
+use nb;
+use void;
 
 pub mod mutex;
 pub mod proxy;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,8 @@
 #![cfg_attr(feature = "docsrs", feature(extern_prelude))]
 
 #[cfg(feature = "cortexm")]
-extern crate cortex_m;
-extern crate embedded_hal as hal;
+use cortex_m;
+use embedded_hal as hal;
 
 pub mod mutex;
 pub mod proxy;

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -8,8 +8,8 @@
 /// If there is no feature available for your Mutex type, you have to write one yourself. It should
 /// look something like this (for [`cortex_m`] as an example):
 /// ```
-/// # extern crate shared_bus;
-/// extern crate cortex_m;
+/// use shared_bus;
+/// use cortex_m;
 ///
 /// // You need a newtype because you can't implement foreign traits on
 /// // foreign types.

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,7 +1,7 @@
 use hal::blocking::i2c;
 use hal::blocking::spi;
 
-use mutex;
+use super::*;
 
 #[cfg(feature = "std")]
 use std::cell;
@@ -25,7 +25,7 @@ use core::marker;
 ///
 /// # Examples
 /// ```
-/// # extern crate shared_bus;
+/// # use shared_bus;
 /// # use shared_bus::BusManager;
 /// # struct MyDevice;
 /// # impl MyDevice {

--- a/tests/shared_bus.rs
+++ b/tests/shared_bus.rs
@@ -1,6 +1,6 @@
-extern crate embedded_hal as hal;
-extern crate embedded_hal_mock as hal_mock;
-extern crate shared_bus;
+use embedded_hal as hal;
+use embedded_hal_mock as hal_mock;
+use shared_bus;
 
 use hal::blocking::i2c::Write;
 use hal::blocking::spi::Write as SPIWrite;


### PR DESCRIPTION
Hi @Rahix 

Here is a PR that includes two patches:
* switch to Rust 2018 and update deps
* add Timer proxy

Regards,
Sergey