### PR TITLE
[RFC] WIP: shared adc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,11 @@ categories = ["embedded", "no-std"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-embedded-hal = "0.2.3"
+nb = "0.1.2"
+
+[dependencies.embedded-hal]
+version = "0.2.3"
+features=["unproven"]
 
 [dev-dependencies]
 embedded-hal-mock = "0.7.0"

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,3 +1,4 @@
+use hal::adc::{Channel, OneShot};
 use hal::blocking::i2c;
 use hal::blocking::spi;
 
@@ -148,6 +149,22 @@ where
         self.0.lock(|lock| {
             let mut i = lock.borrow_mut();
             i.write(words)
+        })
+    }
+}
+
+impl<'a, M, ADC, WORD, PIN, AS: OneShot<ADC, WORD, PIN>> OneShot<ADC, WORD, PIN>
+    for BusProxy<'a, M, AS>
+where
+    PIN: Channel<ADC>,
+    M: 'a + mutex::BusMutex<cell::RefCell<AS>>,
+{
+    type Error = AS::Error;
+
+    fn read(&mut self, pin: &mut PIN) -> nb::Result<WORD, Self::Error> {
+        self.0.lock(|lock| {
+            let mut i = lock.borrow_mut();
+            i.read(pin)
         })
     }
 }


### PR DESCRIPTION
Hi @Rahix 

Here is an attempt to implement ADC proxy. The first commit is the same as in #5 , so it will be removed as soon as ```shared-bus``` is updated for Rust 2018. 

Suggested implementation is not complete and has issues. However so far I could not find a proper way to fix them. So the purpose of this PR is to get feedback and find a better approach for shared ADC. 

### Example 1: using shared ADC for single channel
The following example appears to be working (full example is [here](https://github.com/geomatsi/rust-blue-pill-tests/blob/master/src/bin/shared-adc-single-chan.rs)) for single channel ```Measurement``` wrapper:
```
pub struct Measurement<'a, ADC, PIN>
where
    PIN: Channel<ADC, ID = u8>,
{
    adc: &'a mut dyn OneShot<ADC, u16, PIN, Error = ()>,
    pin: PIN,
}

impl<'a, ADC, PIN> Measurement<'a, ADC, PIN>
where
    PIN: Channel<ADC, ID = u8>,
{
    pub fn init(adc: &'a mut dyn OneShot<ADC, u16, PIN, Error = ()>, pin: PIN) -> Self {
        Measurement { adc, pin }
    }

    pub fn test(&mut self) -> u16 {
        self.adc.read(&mut self.pin).unwrap()
    }
}
```
And then create multiple instances each using different channel:
```
    type AdcType = Adc<stm32::ADC1>;

     ...

    let ch0 = gpioa.pa0.into_analog(&mut gpioa.crl);
    let ch1 = gpioa.pa1.into_analog(&mut gpioa.crl);

    let adc = Adc::adc1(p.ADC1, &mut rcc.apb2, clocks);
    let adc_bus = shared_bus::BusManager::<
        cm::interrupt::Mutex<core::cell::RefCell<AdcType>>,
        AdcType,
    >::new(adc);

    let mut adc_mgr1 = adc_bus.acquire();
    let mut adc_mgr2 = adc_bus.acquire();

    let mut a = Measurement::init(&mut adc_mgr1, ch0);
    let mut b = Measurement::init(&mut adc_mgr2, ch1);

    a.test();
    b.test();
```

### Example 2: using shared ADC for multiple channels
Similar approach does not work for ```Measurement``` with multiple channels (full example [here](https://github.com/geomatsi/rust-blue-pill-tests/blob/master/src/bin/shared-adc-multiple-chans.rs)):
```
pub struct Measurement<'a, ADC, PIN>
where
    PIN: Channel<ADC, ID = u8>,
{
    adc: &'a mut dyn OneShot<ADC, u16, PIN, Error = ()>,
    pin1: PIN,
    pin2: PIN,
}

impl<'a, ADC, PIN> Measurement<'a, ADC, PIN>
where
    PIN: Channel<ADC, ID = u8>,
{
    pub fn init(adc: &'a mut dyn OneShot<ADC, u16, PIN, Error = ()>, pin1: PIN, pin2: PIN) -> Self {
        Measurement { adc, pin1, pin2 }
    }

    pub fn test1(&mut self) -> u16 {
        self.adc.read(self.pin1).unwrap()
    }

    pub fn test2(&mut self) -> u16 {
        self.adc.read(self.pin2).unwrap()
    }
}
```
Due to strict type inference the following snippet results in compilation error:
```
    let mut gpioa = p.GPIOA.split(&mut rcc.apb2);
    let ch0 = gpioa.pa0.into_analog(&mut gpioa.crl);
    let ch1 = gpioa.pa1.into_analog(&mut gpioa.crl);
    let ch2 = gpioa.pa2.into_analog(&mut gpioa.crl);
    let ch3 = gpioa.pa3.into_analog(&mut gpioa.crl);

    let adc = Adc::adc1(p.ADC1, &mut rcc.apb2, clocks);
    let adc_bus = shared_bus::BusManager::<
        cm::interrupt::Mutex<core::cell::RefCell<AdcType>>,
        AdcType,
    >::new(adc);

    let mut adc_mgr1 = adc_bus.acquire();
    let mut adc_mgr2 = adc_bus.acquire();

    let mut a = Measurement::init(&mut adc_mgr1, ch0, ch1);
    let mut b = Measurement::init(&mut adc_mgr2, ch2, ch3);
```
Compiler expects ch0 and ch1 to be of the same type which is not the case.

Straightforward attempt to fix includes the following two steps:
* switching from ```PIN``` to trait objects ```&'a mut dyn Channel<ADC, ID = u8``` 
* using [workaround](https://github.com/geomatsi/embedded-hal/commit/453b181f8cebfbc3ce53e0ac232fedd01c6ca3b8) for ```method `channel` has no receiver```  issue

However this brings errors for ADC reading in test mehods:
```
     |
36 |         self.adc.read(self.pin1).unwrap()
     |                       ^^^^^^^^^ expected type parameter, found trait embedded_hal::adc::Channel
     |
```

Regards,
Sergey