### PR TITLE
Replace explicit type with `Self` in sample code, where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ extern crate cortex_m;
 struct MyMutex<T>(cortex_m::interrupt::Mutex<T>);
 
 impl<T> shared_bus::BusMutex<T> for MyMutex<T> {
-    fn create(v: T) -> MyMutex<T> {
-        MyMutex(cortex_m::interrupt::Mutex::new(v))
+    fn create(v: T) -> Self {
+        Self(cortex_m::interrupt::Mutex::new(v))
     }
 
     fn lock<R, F: FnOnce(&T) -> R>(&self, f: F) -> R {

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -16,8 +16,8 @@
 /// struct MyMutex<T>(cortex_m::interrupt::Mutex<T>);
 ///
 /// impl<T> shared_bus::BusMutex<T> for MyMutex<T> {
-///     fn create(v: T) -> MyMutex<T> {
-///         MyMutex(cortex_m::interrupt::Mutex::new(v))
+///     fn create(v: T) -> Self {
+///         Self(cortex_m::interrupt::Mutex::new(v))
 ///     }
 ///
 ///     fn lock<R, F: FnOnce(&T) -> R>(&self, f: F) -> R {


### PR DESCRIPTION
I would assume that many people end up renaming `MyMutex`. Using `Self` makes this quicker.