### PR TITLE
Add a NullMutex for sharing within a single task/thread

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,15 @@ pub mod mutex;
 pub mod proxy;
 
 pub use mutex::BusMutex;
+pub use mutex::NullMutex;
 pub use proxy::BusManager;
 pub use proxy::BusProxy;
+
+/// Type alias for a bus manager using the [`shared_bus::NullMutex`].
+///
+/// This bus manager can be used when all bus users are contained in a single execution context,
+/// i.e. no synchronization between different tasks/threads is needed.
+pub type SingleContextBusManager<L, P> = BusManager<NullMutex<L>, P>;
 
 /// Type alias for a bus manager using [`std::sync::Mutex`].
 ///

--- a/tests/shared_bus.rs
+++ b/tests/shared_bus.rs
@@ -86,3 +86,24 @@ fn multiple_proxies() {
 
     device.done()
 }
+
+#[test]
+fn null_manager() {
+    let expect = vec![
+        I2cTransaction::write(0x0a, vec![0xab, 0xcd]),
+        I2cTransaction::write(0x0b, vec![0x01, 0x23]),
+        I2cTransaction::write(0x0a, vec![0x00, 0xff]),
+    ];
+    let mut device = I2cMock::new(&expect);
+
+    let manager = shared_bus::SingleContextBusManager::new(device.clone());
+
+    let mut proxy1 = manager.acquire();
+    let mut proxy2 = manager.acquire();
+
+    proxy1.write(0x0A, &[0xab, 0xcd]).unwrap();
+    proxy2.write(0x0B, &[0x01, 0x23]).unwrap();
+    proxy1.write(0x0A, &[0x00, 0xFF]).unwrap();
+
+    device.done()
+}


### PR DESCRIPTION
When all peripherals using the bus live in the same thread, just the RefCell is enough; no actual Mutex type is needed.  This can reduce overhead and doesn't unnecessarily block other tasks (e.g. by turning off interrupts).

cc @ryan-summers