### PR TITLE
Add an atomic-check mutex for RTIC

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ overview of what's already available:
 | --- | --- | --- | --- |
 | `std::sync::Mutex` | [`BusManagerStd`] | [`new_std!()`] | `std` |
 | `cortex_m::interrupt::Mutex` | [`BusManagerCortexM`] | [`new_cortexm!()`] | `cortex-m` |
+| NA | [`BusManagerAtomicCheck`] | [`new_atomic_check!()`] | `cortex-m` |
 
 # Supported Busses
 Currently, the following busses can be shared with _shared-bus_:
@@ -82,11 +83,13 @@ Currently, the following busses can be shared with _shared-bus_:
 [`.acquire_spi()`]: https://docs.rs/shared-bus/latest/shared_bus/struct.BusManager.html#method.acquire_spi
 [`BusManagerCortexM`]: https://docs.rs/shared-bus/latest/shared_bus/type.BusManagerCortexM.html
 [`BusManagerSimple`]: https://docs.rs/shared-bus/latest/shared_bus/type.BusManagerSimple.html
+[`BusManagerAtomicCheck`]: https://docs.rs/shared-bus/latest/shared_bus/type.BusManagerAtomicCheck.html
 [`BusManagerStd`]: https://docs.rs/shared-bus/latest/shared_bus/type.BusManagerStd.html
 [`BusMutex`]: https://docs.rs/shared-bus/latest/shared_bus/trait.BusMutex.html
 [`I2cProxy`]: https://docs.rs/shared-bus/latest/shared_bus/struct.I2cProxy.html
 [`SpiProxy`]: https://docs.rs/shared-bus/latest/shared_bus/struct.SpiProxy.html
 [`new_cortexm!()`]: https://docs.rs/shared-bus/latest/shared_bus/macro.new_cortexm.html
+[`new_atomic_check!()`]: https://docs.rs/shared-bus/latest/shared_bus/macro.new_atomic_check.html
 [`new_std!()`]: https://docs.rs/shared-bus/latest/shared_bus/macro.new_std.html
 [blog-post]: https://blog.rahix.de/001-shared-bus
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@
 //! | --- | --- | --- | --- |
 //! | `std::sync::Mutex` | [`BusManagerStd`] | [`new_std!()`] | `std` |
 //! | `cortex_m::interrupt::Mutex` | [`BusManagerCortexM`] | [`new_cortexm!()`] | `cortex-m` |
+//! | None (Automatically Managed) | [`BusManagerAtomicCheck`] | [`new_atomic_check!()`] | `cortex-m` |
 //!
 //! # Supported Busses
 //! Currently, the following busses can be shared with _shared-bus_:
@@ -98,6 +99,7 @@
 //! [`.acquire_i2c()`]: ./struct.BusManager.html#method.acquire_i2c
 //! [`.acquire_spi()`]: ./struct.BusManager.html#method.acquire_spi
 //! [`BusManagerCortexM`]: ./type.BusManagerCortexM.html
+//! [`BusManagerAtomicCheck`]: ./type.BusManagerAtomicCheck.html
 //! [`BusManagerSimple`]: ./type.BusManagerSimple.html
 //! [`BusManagerStd`]: ./type.BusManagerStd.html
 //! [`BusMutex`]: ./trait.BusMutex.html
@@ -105,16 +107,16 @@
 //! [`SpiProxy`]: ./struct.SpiProxy.html
 //! [`new_cortexm!()`]: ./macro.new_cortexm.html
 //! [`new_std!()`]: ./macro.new_std.html
+//! [`new_atomic_check!()`]: ./macro.new_atomic_check.html
 //! [blog-post]: https://blog.rahix.de/001-shared-bus
 #![doc(html_root_url = "https://docs.rs/shared-bus")]
 #![cfg_attr(not(feature = "std"), no_std)]
-
 #![warn(missing_docs)]
 
+mod macros;
 mod manager;
 mod mutex;
 mod proxies;
-mod macros;
 
 #[doc(hidden)]
 #[cfg(feature = "std")]
@@ -126,9 +128,9 @@ pub use cortex_m;
 
 pub use manager::BusManager;
 pub use mutex::BusMutex;
-pub use mutex::NullMutex;
 #[cfg(feature = "cortex-m")]
 pub use mutex::CortexMMutex;
+pub use mutex::NullMutex;
 pub use proxies::I2cProxy;
 pub use proxies::SpiProxy;
 
@@ -193,6 +195,42 @@ pub type BusManagerStd<BUS> = BusManager<::std::sync::Mutex<BUS>>;
 #[cfg(feature = "cortex-m")]
 pub type BusManagerCortexM<BUS> = BusManager<CortexMMutex<BUS>>;
 
+/// A bus manager for safely sharing the bus when using concurrency frameworks (such as RTIC).
+///
+/// This manager relies on RTIC or some other concurrency framework to manage resource
+/// contention automatically. As a redundancy, this manager uses an atomic boolean to check
+/// whether or not a resource is currently in use. This is purely used as a fail-safe against
+/// misuse.
+///
+/// ## Warning
+/// If devices on the same shared bus are not treated as a singular resource, it is possible that
+/// pre-emption may occur. In this case, the manger will panic to prevent the race condition.
+///
+/// ## Usage
+/// In order to use this manager with a concurrency framework such as RTIC, all devices on the
+/// shared bus must be stored in the same logic resource. The concurrency framework will require a
+/// resource lock if pre-emption is possible.
+///
+/// In order to use this with RTIC (as an example), all devices on the shared bus must be stored in
+/// a singular resource:
+/// ```rust
+/// struct SharedBusResources<T> {
+///     device: Device<shared_bus::I2cProxy<'static, T>>,
+///     other_device: OtherDevice<shared_bus::I2cProxy<'static, T>>,
+/// }
+///
+/// type I2C = ();
+///
+/// struct Resources {
+///     shared_bus_resources: SharedBusResources<I2C>
+/// }
+/// ```
+///
+/// Usually, for sharing / between tasks, a manager with `'static` lifetime is needed which can be
+/// created using the [`shared_bus::new_atomic_check!()`][new_atomic_check] macro.
+///
+/// [new_atomic_check]: ./macro.new_atomic_check.html
+///
+/// This type is only available with the `cortex-m` feature.
 #[cfg(feature = "cortex-m")]
-/// A convenience type for declaring use with shared-bus.
 pub type BusManagerAtomicCheck<T> = BusManager<AtomicCheckMutex<T>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,9 @@ pub use mutex::CortexMMutex;
 pub use proxies::I2cProxy;
 pub use proxies::SpiProxy;
 
+#[cfg(feature = "cortex-m")]
+pub use mutex::AtomicCheckMutex;
+
 /// A bus manager for sharing within a single task/thread.
 ///
 /// This is the bus manager with the least overhead; it should always be used when all bus users
@@ -189,3 +192,7 @@ pub type BusManagerStd<BUS> = BusManager<::std::sync::Mutex<BUS>>;
 /// This type is only available with the `cortex-m` feature.
 #[cfg(feature = "cortex-m")]
 pub type BusManagerCortexM<BUS> = BusManager<CortexMMutex<BUS>>;
+
+#[cfg(feature = "cortex-m")]
+/// A convenience type for declaring use with shared-bus.
+pub type BusManagerAtomicCheck<T> = BusManager<AtomicCheckMutex<T>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,15 +214,19 @@ pub type BusManagerCortexM<BUS> = BusManager<CortexMMutex<BUS>>;
 /// In order to use this with RTIC (as an example), all devices on the shared bus must be stored in
 /// a singular resource:
 /// ```rust
-/// struct SharedBusResources<T> {
-///     device: Device<shared_bus::I2cProxy<'static, T>>,
-///     other_device: OtherDevice<shared_bus::I2cProxy<'static, T>>,
-/// }
+/// struct Device<T> { _bus: T };
+/// struct OtherDevice<T> { _bus: T };
 ///
 /// type I2C = ();
+/// type Proxy = shared_bus::I2cProxy<'static, shared_bus::AtomicCheckMutex<I2C>>;
+///
+/// struct SharedBusResources {
+///     device: Device<Proxy>,
+///     other_device: OtherDevice<Proxy>,
+/// }
 ///
 /// struct Resources {
-///     shared_bus_resources: SharedBusResources<I2C>
+///     shared_bus_resources: SharedBusResources,
 /// }
 /// ```
 ///

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -132,3 +132,17 @@ macro_rules! new_cortexm {
         m
     }};
 }
+
+/// Construct a statically allocated bus manager.
+#[cfg(feature = "cortex-m")]
+#[macro_export]
+macro_rules! new_atomic_check {
+    ($bus_type:ty = $bus:expr) => {{
+        let m: Option<&'static mut _> = $crate::cortex_m::singleton!(
+            : $crate::BusManagerAtomicCheck<$bus_type> =
+                $crate::BusManagerAtomicCheck::new($bus)
+        );
+
+        m
+    }};
+}


### PR DESCRIPTION
This PR adds an `AtomicCheck` "mutex" which does a simple atomic check to ensure that a bus collision does not occur and `panic`s if one does. It is then the user's responsibility to ensure that collisions do not occur (e.g. by using RTIC to manage resources properly). This eliminates any need to disable interrupts and supports high levels of concurrency.

Note that I've currently feature-gated this behind `cortex-m` right now.

There's also an issue when targetting cortex M0 cores I believe (and any armv6 I think) because they don't provide atomic support.