### PR TITLE
Make proxies `Clone`-able

### DIFF
--- a/src/proxies.rs
+++ b/src/proxies.rs
@@ -10,7 +10,7 @@ use embedded_hal::blocking::spi;
 /// An `I2cProxy` is created by calling [`BusManager::acquire_i2c()`][acquire_i2c].
 ///
 /// [acquire_i2c]: ./struct.BusManager.html#method.acquire_i2c
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct I2cProxy<'a, M: crate::BusMutex> {
     pub(crate) mutex: &'a M,
 }
@@ -67,7 +67,7 @@ where
 ///
 /// [acquire_spi]: ./struct.BusManager.html#method.acquire_spi
 /// [`BusManagerSimple`]: ./type.BusManagerSimple.html
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SpiProxy<'a, M: crate::BusMutex> {
     pub(crate) mutex: &'a M,
     pub(crate) _u: core::marker::PhantomData<*mut ()>,


### PR DESCRIPTION
There is nothing preventing us from creating a new proxy from an existing one because fundamentally they just wrap a shared reference.

This might be useful for drivers that need to split bus access again internally and want to directly consume a BusProxy for that purpose.