### PR TITLE
Add ADC proxy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ xtensa-lx6 = { version = "0.2.0", optional = true }
 spin = { version = "0.9.2", optional = true }
 
 [dev-dependencies]
-embedded-hal-mock = "0.7.0"
+embedded-hal-mock = "0.8"
 
 [features]
 std = ["once_cell"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ all-features = true
 
 [dependencies]
 embedded-hal = "0.2.3"
+nb = "0.1.3"
 once_cell = { version = "1.4.0", optional = true }
 cortex-m = { version = "0.6.3", optional = true }
 xtensa-lx6 = { version = "0.2.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,17 +88,19 @@
 //! | `shared_bus::XtensaMutex` (`spin::Mutex` in critical section) | [`BusManagerXtensa`] | [`new_xtensa!()`] | `xtensa` |
 //! | None (Automatically Managed) | [`BusManagerAtomicCheck`] | [`new_atomic_check!()`] | `cortex-m` |
 //!
-//! # Supported Busses
-//! Currently, the following busses can be shared with _shared-bus_:
+//! # Supported buses and hardware blocks
+//! Currently, the following buses/blocks can be shared with _shared-bus_:
 //!
-//! | Bus | Proxy Type | Acquire Method | Comments |
+//! | Bus/Block | Proxy Type | Acquire Method | Comments |
 //! | --- | --- | --- | --- |
 //! | I2C | [`I2cProxy`] | [`.acquire_i2c()`] | |
 //! | SPI | [`SpiProxy`] | [`.acquire_spi()`] | SPI can only be shared within a single task (See [`SpiProxy`] for details). |
+//! | ADC | [`AdcProxy`] | [`.acquire_adc()`] | |
 //!
 //!
 //! [`.acquire_i2c()`]: ./struct.BusManager.html#method.acquire_i2c
 //! [`.acquire_spi()`]: ./struct.BusManager.html#method.acquire_spi
+//! [`.acquire_adc()`]: ./struct.BusManager.html#method.acquire_adc
 //! [`BusManagerCortexM`]: ./type.BusManagerCortexM.html
 //! [`BusManagerXtensa`]: ./type.BusManagerXtensa.html
 //! [`BusManagerAtomicCheck`]: ./type.BusManagerAtomicCheck.html
@@ -107,6 +109,7 @@
 //! [`BusMutex`]: ./trait.BusMutex.html
 //! [`I2cProxy`]: ./struct.I2cProxy.html
 //! [`SpiProxy`]: ./struct.SpiProxy.html
+//! [`AdcProxy`]: ./struct.AdcProxy.html
 //! [`new_cortexm!()`]: ./macro.new_cortexm.html
 //! [`new_xtensa!()`]: ./macro.new_xtensa.html
 //! [`new_std!()`]: ./macro.new_std.html
@@ -140,6 +143,7 @@ pub use mutex::CortexMMutex;
 pub use mutex::NullMutex;
 #[cfg(feature = "xtensa")]
 pub use mutex::XtensaMutex;
+pub use proxies::AdcProxy;
 pub use proxies::I2cProxy;
 pub use proxies::SpiProxy;
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -130,6 +130,31 @@ impl<M: crate::BusMutex> BusManager<M> {
     pub fn acquire_i2c<'a>(&'a self) -> crate::I2cProxy<'a, M> {
         crate::I2cProxy { mutex: &self.mutex }
     }
+
+    /// Acquire an [`AdcProxy`] for this hardware block.
+    ///
+    /// [`AdcProxy`]: ./struct.AdcProxy.html
+    ///
+    /// The returned proxy object can then be used for accessing the bus by e.g. a driver:
+    ///
+    /// ```ignore
+    /// // For example:
+    /// // let ch0 = gpioa.pa0.into_analog(&mut gpioa.crl);
+    /// // let ch1 = gpioa.pa1.into_analog(&mut gpioa.crl);
+    /// // let adc = Adc::adc1(p.ADC1, &mut rcc.apb2, clocks);
+    ///
+    /// let adc_bus: &'static _ = shared_bus::new_cortexm!(Adc<ADC1> = adc).unwrap();
+    /// let mut proxy1 = adc_bus.acquire_adc();
+    /// let mut proxy2 = adc_bus.acquire_adc();
+    ///
+    /// proxy1.read(ch0).unwrap();
+    /// proxy2.read(ch1).unwrap();
+    ///
+    /// ```
+
+    pub fn acquire_adc<'a>(&'a self) -> crate::AdcProxy<'a, M> {
+        crate::AdcProxy { mutex: &self.mutex }
+    }
 }
 
 impl<T> BusManager<crate::NullMutex<T>> {

--- a/src/proxies.rs
+++ b/src/proxies.rs
@@ -17,9 +17,7 @@ pub struct I2cProxy<'a, M> {
 
 impl<'a, M: crate::BusMutex> Clone for I2cProxy<'a, M> {
     fn clone(&self) -> Self {
-        Self {
-            mutex: &self.mutex,
-        }
+        Self { mutex: &self.mutex }
     }
 }
 
@@ -57,11 +55,10 @@ where
         buffer_in: &[u8],
         buffer_out: &mut [u8],
     ) -> Result<(), Self::Error> {
-        self.mutex.lock(|bus| bus.write_read(addr, buffer_in, buffer_out))
+        self.mutex
+            .lock(|bus| bus.write_read(addr, buffer_in, buffer_out))
     }
 }
-
-
 
 /// Proxy type for SPI bus sharing.
 ///

--- a/tests/adc.rs
+++ b/tests/adc.rs
@@ -1,0 +1,107 @@
+use embedded_hal::prelude::*;
+use embedded_hal_mock::adc;
+use std::thread;
+
+#[test]
+fn adc_mock_device() {
+    let expectations = [
+        adc::Transaction::read(0, 0xabcd),
+        adc::Transaction::read(1, 0xabba),
+        adc::Transaction::read(2, 0xbaab),
+    ];
+
+    let mut device = adc::Mock::new(&expectations);
+    assert_eq!(0xabcd, device.read(&mut adc::MockChan0).unwrap());
+    assert_eq!(0xabba, device.read(&mut adc::MockChan1).unwrap());
+    assert_eq!(0xbaab, device.read(&mut adc::MockChan2).unwrap());
+    device.done()
+}
+
+#[test]
+fn adc_manager_simple() {
+    let expectations = [
+        adc::Transaction::read(0, 0xabcd),
+        adc::Transaction::read(1, 0xabba),
+        adc::Transaction::read(2, 0xbaab),
+    ];
+
+    let mut device = adc::Mock::new(&expectations);
+    let manager = shared_bus::BusManagerSimple::new(device.clone());
+    let mut proxy = manager.acquire_adc();
+
+    assert_eq!(0xabcd, proxy.read(&mut adc::MockChan0).unwrap());
+    assert_eq!(0xabba, proxy.read(&mut adc::MockChan1).unwrap());
+    assert_eq!(0xbaab, proxy.read(&mut adc::MockChan2).unwrap());
+    device.done()
+}
+
+#[test]
+fn adc_manager_std() {
+    let expectations = [
+        adc::Transaction::read(0, 0xabcd),
+        adc::Transaction::read(1, 0xabba),
+        adc::Transaction::read(2, 0xbaab),
+    ];
+
+    let mut device = adc::Mock::new(&expectations);
+    let manager: &'static shared_bus::BusManagerStd<_> =
+        shared_bus::new_std!(adc::Mock<u16> = device.clone()).unwrap();
+    let mut proxy = manager.acquire_adc();
+
+    assert_eq!(0xabcd, proxy.read(&mut adc::MockChan0).unwrap());
+    assert_eq!(0xabba, proxy.read(&mut adc::MockChan1).unwrap());
+    assert_eq!(0xbaab, proxy.read(&mut adc::MockChan2).unwrap());
+    device.done()
+}
+
+#[test]
+fn adc_proxy_multi() {
+    let expectations = [
+        adc::Transaction::read(0, 0xabcd),
+        adc::Transaction::read(1, 0xabba),
+        adc::Transaction::read(2, 0xbaab),
+    ];
+
+    let mut device = adc::Mock::new(&expectations);
+    let manager = shared_bus::BusManagerSimple::new(device.clone());
+    let mut proxy1 = manager.acquire_adc();
+    let mut proxy2 = manager.acquire_adc();
+    let mut proxy3 = manager.acquire_adc();
+
+    assert_eq!(0xabcd, proxy1.read(&mut adc::MockChan0).unwrap());
+    assert_eq!(0xabba, proxy2.read(&mut adc::MockChan1).unwrap());
+    assert_eq!(0xbaab, proxy3.read(&mut adc::MockChan2).unwrap());
+    device.done()
+}
+
+#[test]
+fn adc_proxy_concurrent() {
+    let expectations = [
+        adc::Transaction::read(0, 0xabcd),
+        adc::Transaction::read(1, 0xabba),
+        adc::Transaction::read(2, 0xbaab),
+    ];
+
+    let mut device = adc::Mock::new(&expectations);
+    let manager: &'static shared_bus::BusManagerStd<_> =
+        shared_bus::new_std!(adc::Mock<u32> = device.clone()).unwrap();
+    let mut proxy1 = manager.acquire_adc();
+    let mut proxy2 = manager.acquire_adc();
+    let mut proxy3 = manager.acquire_adc();
+
+    thread::spawn(move || {
+        assert_eq!(0xabcd, proxy1.read(&mut adc::MockChan0).unwrap());
+    })
+    .join()
+    .unwrap();
+
+    thread::spawn(move || {
+        assert_eq!(0xabba, proxy2.read(&mut adc::MockChan1).unwrap());
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(0xbaab, proxy3.read(&mut adc::MockChan2).unwrap());
+
+    device.done()
+}

--- a/tests/i2c.rs
+++ b/tests/i2c.rs
@@ -12,9 +12,7 @@ fn fake_i2c_device() {
 
 #[test]
 fn i2c_manager_manual() {
-    let expect = vec![
-        i2c::Transaction::write(0xde, vec![0xad, 0xbe, 0xef]),
-    ];
+    let expect = vec![i2c::Transaction::write(0xde, vec![0xad, 0xbe, 0xef])];
     let mut device = i2c::Mock::new(&expect);
     let manager = shared_bus::BusManagerSimple::new(device.clone());
     let mut proxy = manager.acquire_i2c();
@@ -26,9 +24,7 @@ fn i2c_manager_manual() {
 
 #[test]
 fn i2c_manager_macro() {
-    let expect = vec![
-        i2c::Transaction::write(0xde, vec![0xad, 0xbe, 0xef]),
-    ];
+    let expect = vec![i2c::Transaction::write(0xde, vec![0xad, 0xbe, 0xef])];
     let mut device = i2c::Mock::new(&expect);
     let manager: &'static shared_bus::BusManagerStd<_> =
         shared_bus::new_std!(i2c::Mock = device.clone()).unwrap();
@@ -105,13 +101,17 @@ fn i2c_concurrent() {
 
     thread::spawn(move || {
         proxy1.write(0xde, &[0xad, 0xbe, 0xef]).unwrap();
-    }).join().unwrap();
+    })
+    .join()
+    .unwrap();
 
     thread::spawn(move || {
         let mut buf = [0u8; 3];
         proxy2.read(0xef, &mut buf).unwrap();
         assert_eq!(&buf, &[0xbe, 0xad, 0xde]);
-    }).join().unwrap();
+    })
+    .join()
+    .unwrap();
 
     device.done();
 }

--- a/tests/spi.rs
+++ b/tests/spi.rs
@@ -11,9 +11,7 @@ fn fake_spi_device() {
 
 #[test]
 fn spi_manager_manual() {
-    let expect = vec![
-        spi::Transaction::write(vec![0xab, 0xcd, 0xef]),
-    ];
+    let expect = vec![spi::Transaction::write(vec![0xab, 0xcd, 0xef])];
     let mut device = spi::Mock::new(&expect);
     let manager = shared_bus::BusManagerSimple::new(device.clone());
     let mut proxy = manager.acquire_spi();


### PR DESCRIPTION
Hi,

This PR adds new proxy type for sharing access to ADC hardware block. The ```AdcProxy``` implements ```OneShot``` trait so it can be passed to drivers instead of ADC instance. PR also includes some tests for the new proxy type based on ```embedded-hal-mock```.

Regards,
Sergey
