### PR TITLE
WIP: Replace specific proxy types I2cProxy and AdcProxy by generic type Proxy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,8 @@
 //!
 //! let bus = shared_bus::BusManagerSimple::new(i2c);
 //!
-//! let mut proxy1 = bus.acquire_i2c();
-//! let mut my_device = MyDevice::new(bus.acquire_i2c());
+//! let mut proxy1 = bus.acquire();
+//! let mut my_device = MyDevice::new(bus.acquire());
 //!
 //! proxy1.write(0x39, &[0xc0, 0xff, 0xee]);
 //! my_device.do_something_on_the_bus();
@@ -67,8 +67,8 @@
 //! // shared with other threads.
 //! let bus: &'static _ = shared_bus::new_std!(SomeI2cBus = i2c).unwrap();
 //!
-//! let mut proxy1 = bus.acquire_i2c();
-//! let mut my_device = MyDevice::new(bus.acquire_i2c());
+//! let mut proxy1 = bus.acquire();
+//! let mut my_device = MyDevice::new(bus.acquire());
 //!
 //! // We can easily move a proxy to another thread:
 //! # let t =
@@ -143,8 +143,7 @@ pub use mutex::CortexMMutex;
 pub use mutex::NullMutex;
 #[cfg(feature = "xtensa")]
 pub use mutex::XtensaMutex;
-pub use proxies::AdcProxy;
-pub use proxies::I2cProxy;
+pub use proxies::Proxy;
 pub use proxies::SpiProxy;
 
 #[cfg(feature = "cortex-m")]
@@ -174,8 +173,8 @@ pub use mutex::AtomicCheckMutex;
 ///
 /// let bus = shared_bus::BusManagerSimple::new(i2c);
 ///
-/// let mut proxy1 = bus.acquire_i2c();
-/// let mut my_device = MyDevice::new(bus.acquire_i2c());
+/// let mut proxy1 = bus.acquire();
+/// let mut my_device = MyDevice::new(bus.acquire());
 ///
 /// proxy1.write(0x39, &[0xc0, 0xff, 0xee]);
 /// my_device.do_something_on_the_bus();

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -30,8 +30,8 @@
 /// // shared with other threads.
 /// let bus: &'static _ = shared_bus::new_std!(SomeI2cBus = i2c).unwrap();
 ///
-/// let mut proxy1 = bus.acquire_i2c();
-/// let mut my_device = MyDevice::new(bus.acquire_i2c());
+/// let mut proxy1 = bus.acquire();
+/// let mut my_device = MyDevice::new(bus.acquire());
 ///
 /// // We can easily move a proxy to another thread:
 /// # let t =

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -41,8 +41,8 @@
 ///
 ///    let bus = shared_bus::BusManagerSimple::new(i2c);
 ///
-///    let mut proxy1 = bus.acquire_i2c();
-///    let mut my_device = MyDevice::new(bus.acquire_i2c());
+///    let mut proxy1 = bus.acquire();
+///    let mut my_device = MyDevice::new(bus.acquire());
 ///
 ///    proxy1.write(0x39, &[0xc0, 0xff, 0xee]);
 ///    my_device.do_something_on_the_bus();
@@ -69,8 +69,8 @@
 ///    // shared with other threads.
 ///    let bus: &'static _ = shared_bus::new_std!(SomeI2cBus = i2c).unwrap();
 ///
-///    let mut proxy1 = bus.acquire_i2c();
-///    let mut my_device = MyDevice::new(bus.acquire_i2c());
+///    let mut proxy1 = bus.acquire();
+///    let mut my_device = MyDevice::new(bus.acquire());
 ///
 ///    // We can easily move a proxy to another thread:
 ///    # let t =
@@ -120,15 +120,15 @@ impl<M: crate::BusMutex> BusManager<M> {
     /// # fn _example(i2c: impl i2c::Write) {
     /// let bus = shared_bus::BusManagerSimple::new(i2c);
     ///
-    /// let mut proxy1 = bus.acquire_i2c();
-    /// let mut my_device = MyDevice::new(bus.acquire_i2c());
+    /// let mut proxy1 = bus.acquire();
+    /// let mut my_device = MyDevice::new(bus.acquire());
     ///
     /// proxy1.write(0x39, &[0xc0, 0xff, 0xee]);
     /// my_device.do_something_on_the_bus();
     /// # }
     /// ```
-    pub fn acquire_i2c<'a>(&'a self) -> crate::I2cProxy<'a, M> {
-        crate::I2cProxy { mutex: &self.mutex }
+    pub fn acquire<'a>(&'a self) -> crate::Proxy<'a, M> {
+        crate::Proxy { mutex: &self.mutex }
     }
 
     /// Acquire an [`AdcProxy`] for this hardware block.
@@ -152,8 +152,8 @@ impl<M: crate::BusMutex> BusManager<M> {
     ///
     /// ```
 
-    pub fn acquire_adc<'a>(&'a self) -> crate::AdcProxy<'a, M> {
-        crate::AdcProxy { mutex: &self.mutex }
+    pub fn acquire_adc<'a>(&'a self) -> crate::Proxy<'a, M> {
+        crate::Proxy { mutex: &self.mutex }
     }
 }
 
@@ -198,7 +198,6 @@ impl<T> BusManager<crate::NullMutex<T>> {
     pub fn acquire_spi<'a>(&'a self) -> crate::SpiProxy<'a, crate::NullMutex<T>> {
         crate::SpiProxy {
             mutex: &self.mutex,
-            _u: core::marker::PhantomData,
         }
     }
 }

--- a/src/proxies.rs
+++ b/src/proxies.rs
@@ -12,17 +12,17 @@ use embedded_hal::blocking::spi;
 ///
 /// [acquire_i2c]: ./struct.BusManager.html#method.acquire_i2c
 #[derive(Debug)]
-pub struct I2cProxy<'a, M> {
+pub struct Proxy<'a, M> {
     pub(crate) mutex: &'a M,
 }
 
-impl<'a, M: crate::BusMutex> Clone for I2cProxy<'a, M> {
+impl<'a, M: crate::BusMutex> Clone for Proxy<'a, M> {
     fn clone(&self) -> Self {
         Self { mutex: &self.mutex }
     }
 }
 
-impl<'a, M: crate::BusMutex> i2c::Write for I2cProxy<'a, M>
+impl<'a, M: crate::BusMutex> i2c::Write for Proxy<'a, M>
 where
     M::Bus: i2c::Write,
 {
@@ -33,7 +33,7 @@ where
     }
 }
 
-impl<'a, M: crate::BusMutex> i2c::Read for I2cProxy<'a, M>
+impl<'a, M: crate::BusMutex> i2c::Read for Proxy<'a, M>
 where
     M::Bus: i2c::Read,
 {
@@ -44,7 +44,7 @@ where
     }
 }
 
-impl<'a, M: crate::BusMutex> i2c::WriteRead for I2cProxy<'a, M>
+impl<'a, M: crate::BusMutex> i2c::WriteRead for Proxy<'a, M>
 where
     M::Bus: i2c::WriteRead,
 {
@@ -76,15 +76,11 @@ where
 #[derive(Debug)]
 pub struct SpiProxy<'a, M> {
     pub(crate) mutex: &'a M,
-    pub(crate) _u: core::marker::PhantomData<*mut ()>,
 }
 
 impl<'a, M: crate::BusMutex> Clone for SpiProxy<'a, M> {
     fn clone(&self) -> Self {
-        Self {
-            mutex: &self.mutex,
-            _u: core::marker::PhantomData,
-        }
+        Self { mutex: &self.mutex }
     }
 }
 
@@ -127,18 +123,8 @@ where
 /// returned.
 ///
 /// [acquire_adc]: ./struct.BusManager.html#method.acquire_adc
-#[derive(Debug)]
-pub struct AdcProxy<'a, M> {
-    pub(crate) mutex: &'a M,
-}
 
-impl<'a, M: crate::BusMutex> Clone for AdcProxy<'a, M> {
-    fn clone(&self) -> Self {
-        Self { mutex: &self.mutex }
-    }
-}
-
-impl<'a, M: crate::BusMutex, ADC, Word, Pin> adc::OneShot<ADC, Word, Pin> for AdcProxy<'a, M>
+impl<'a, M: crate::BusMutex, ADC, Word, Pin> adc::OneShot<ADC, Word, Pin> for Proxy<'a, M>
 where
     Pin: adc::Channel<ADC>,
     M::Bus: adc::OneShot<ADC, Word, Pin>,

--- a/tests/adc.rs
+++ b/tests/adc.rs
@@ -27,7 +27,7 @@ fn adc_manager_simple() {
 
     let mut device = adc::Mock::new(&expectations);
     let manager = shared_bus::BusManagerSimple::new(device.clone());
-    let mut proxy = manager.acquire_adc();
+    let mut proxy = manager.acquire();
 
     assert_eq!(0xabcd, proxy.read(&mut adc::MockChan0).unwrap());
     assert_eq!(0xabba, proxy.read(&mut adc::MockChan1).unwrap());
@@ -46,7 +46,7 @@ fn adc_manager_std() {
     let mut device = adc::Mock::new(&expectations);
     let manager: &'static shared_bus::BusManagerStd<_> =
         shared_bus::new_std!(adc::Mock<u16> = device.clone()).unwrap();
-    let mut proxy = manager.acquire_adc();
+    let mut proxy = manager.acquire();
 
     assert_eq!(0xabcd, proxy.read(&mut adc::MockChan0).unwrap());
     assert_eq!(0xabba, proxy.read(&mut adc::MockChan1).unwrap());
@@ -64,9 +64,9 @@ fn adc_proxy_multi() {
 
     let mut device = adc::Mock::new(&expectations);
     let manager = shared_bus::BusManagerSimple::new(device.clone());
-    let mut proxy1 = manager.acquire_adc();
-    let mut proxy2 = manager.acquire_adc();
-    let mut proxy3 = manager.acquire_adc();
+    let mut proxy1 = manager.acquire();
+    let mut proxy2 = manager.acquire();
+    let mut proxy3 = manager.acquire();
 
     assert_eq!(0xabcd, proxy1.read(&mut adc::MockChan0).unwrap());
     assert_eq!(0xabba, proxy2.read(&mut adc::MockChan1).unwrap());
@@ -85,9 +85,9 @@ fn adc_proxy_concurrent() {
     let mut device = adc::Mock::new(&expectations);
     let manager: &'static shared_bus::BusManagerStd<_> =
         shared_bus::new_std!(adc::Mock<u32> = device.clone()).unwrap();
-    let mut proxy1 = manager.acquire_adc();
-    let mut proxy2 = manager.acquire_adc();
-    let mut proxy3 = manager.acquire_adc();
+    let mut proxy1 = manager.acquire();
+    let mut proxy2 = manager.acquire();
+    let mut proxy3 = manager.acquire();
 
     thread::spawn(move || {
         assert_eq!(0xabcd, proxy1.read(&mut adc::MockChan0).unwrap());

--- a/tests/i2c.rs
+++ b/tests/i2c.rs
@@ -15,7 +15,7 @@ fn i2c_manager_manual() {
     let expect = vec![i2c::Transaction::write(0xde, vec![0xad, 0xbe, 0xef])];
     let mut device = i2c::Mock::new(&expect);
     let manager = shared_bus::BusManagerSimple::new(device.clone());
-    let mut proxy = manager.acquire_i2c();
+    let mut proxy = manager.acquire();
 
     proxy.write(0xde, &[0xad, 0xbe, 0xef]).unwrap();
 
@@ -28,7 +28,7 @@ fn i2c_manager_macro() {
     let mut device = i2c::Mock::new(&expect);
     let manager: &'static shared_bus::BusManagerStd<_> =
         shared_bus::new_std!(i2c::Mock = device.clone()).unwrap();
-    let mut proxy = manager.acquire_i2c();
+    let mut proxy = manager.acquire();
 
     proxy.write(0xde, &[0xad, 0xbe, 0xef]).unwrap();
 
@@ -45,7 +45,7 @@ fn i2c_proxy() {
     let mut device = i2c::Mock::new(&expect);
 
     let manager = shared_bus::BusManagerSimple::new(device.clone());
-    let mut proxy = manager.acquire_i2c();
+    let mut proxy = manager.acquire();
 
     proxy.write(0xde, &[0xad, 0xbe, 0xef]).unwrap();
 
@@ -70,9 +70,9 @@ fn i2c_multi() {
     let mut device = i2c::Mock::new(&expect);
 
     let manager = shared_bus::BusManagerSimple::new(device.clone());
-    let mut proxy1 = manager.acquire_i2c();
-    let mut proxy2 = manager.acquire_i2c();
-    let mut proxy3 = manager.acquire_i2c();
+    let mut proxy1 = manager.acquire();
+    let mut proxy2 = manager.acquire();
+    let mut proxy3 = manager.acquire();
 
     proxy1.write(0xde, &[0xad, 0xbe, 0xef]).unwrap();
 
@@ -96,8 +96,8 @@ fn i2c_concurrent() {
     let mut device = i2c::Mock::new(&expect);
 
     let manager = shared_bus::new_std!(i2c::Mock = device.clone()).unwrap();
-    let mut proxy1 = manager.acquire_i2c();
-    let mut proxy2 = manager.acquire_i2c();
+    let mut proxy1 = manager.acquire();
+    let mut proxy2 = manager.acquire();
 
     thread::spawn(move || {
         proxy1.write(0xde, &[0xad, 0xbe, 0xef]).unwrap();


### PR DESCRIPTION
I have seen that the different proxy types (`I2cProxy`, `SpiProxy` and `AdcProxy`) are essentially the same types. The only difference for the `SpiProxy` is that should only be initialized with the `NullMutex`. So I guess this can be reduced to only two types there.

Also, the `SpiProxy::_u` field had no apparent use so I removed it. Have I overlooked something there?

This is WIP because I have not adjusted the documentation and removed the `acquire_adc` method yet.