### PR TITLE
Update xtensa-lx support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ embedded-hal = "0.2.3"
 nb = "0.1.3"
 once_cell = { version = "1.4.0", optional = true }
 cortex-m = { version = "0.6.3", optional = true }
-xtensa-lx6 = { version = "0.2.0", optional = true }
+xtensa-lx = { version = "0.6.0", optional = true }
 spin = { version = "0.9.2", optional = true }
 
 [dev-dependencies]
@@ -28,4 +28,4 @@ embedded-hal-mock = "0.8"
 
 [features]
 std = ["once_cell"]
-xtensa = ["xtensa-lx6", "spin"]
+xtensa = ["xtensa-lx", "spin"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ pub use cortex_m;
 
 #[doc(hidden)]
 #[cfg(feature = "xtensa")]
-pub use xtensa_lx6;
+pub use xtensa_lx;
 
 pub use manager::BusManager;
 pub use mutex::BusMutex;

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -143,7 +143,7 @@ impl<T> BusMutex for XtensaMutex<T> {
     }
 
     fn lock<R, F: FnOnce(&mut Self::Bus) -> R>(&self, f: F) -> R {
-        xtensa_lx6::interrupt::free(|_| f(&mut (*self.0.lock())))
+        xtensa_lx::interrupt::free(|_| f(&mut (*self.0.lock())))
     }
 }
 


### PR DESCRIPTION
Fix #27 

The upstream crate was renamed and updated.
Changing the reference fixes this.