### PR TITLE
Use atomic-polyfill for AtomicCheckMutex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ once_cell = { version = "1.4.0", optional = true }
 cortex-m = { version = "0.6.3", optional = true }
 xtensa-lx = { version = "0.6.0", optional = true }
 spin = { version = "0.9.2", optional = true }
+atomic-polyfill = "0.1.6"
 
 [dev-dependencies]
 embedded-hal-mock = "0.8"

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -184,7 +184,7 @@ mod tests {
 #[derive(Debug)]
 pub struct AtomicCheckMutex<BUS> {
     bus: core::cell::UnsafeCell<BUS>,
-    busy: core::sync::atomic::AtomicBool,
+    busy: atomic_polyfill::AtomicBool,
 }
 
 // It is explicitly safe to share this across threads because there is a coherency check using an
@@ -199,7 +199,7 @@ impl<BUS> BusMutex for AtomicCheckMutex<BUS> {
     fn create(v: BUS) -> Self {
         Self {
             bus: core::cell::UnsafeCell::new(v),
-            busy: core::sync::atomic::AtomicBool::from(false),
+            busy: atomic_polyfill::AtomicBool::from(false),
         }
     }
 


### PR DESCRIPTION
This will allow using `shared-bus` on thumbv6 platforms which do not have real atomics.

@pdgilbert, can you please give this a try on your systems to verify that it actually works now?

Fixes #29.