### PR TITLE
Implement i2c proxy for embedded-hal 1.0.0-alpha.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ xtensa-lx = { version = "0.6.0", optional = true }
 spin = { version = "0.9.2", optional = true }
 atomic-polyfill = { version = "0.1.6", optional = true }
 
+embedded-hal-alpha = { package = "embedded-hal", version = "=1.0.0-alpha.8", optional = true }
+
 [dev-dependencies]
 embedded-hal-mock = "0.8"
 
@@ -31,3 +33,4 @@ embedded-hal-mock = "0.8"
 std = ["once_cell"]
 xtensa = ["xtensa-lx", "spin"]
 cortex-m = ["dep:cortex-m", "atomic-polyfill"]
+eh-alpha = ["embedded-hal-alpha"]


### PR DESCRIPTION
Some drivers and HALs have already started using the embedded-hal alpha releases so it seems we really need to add support for them now.

As a starting point, implement i2c sharing ontop of the blocking I2C trait from the embedded-hal alpha 8.