### PR TITLE
Corrected Xtensa_lx function name

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -151,7 +151,7 @@ macro_rules! new_cortexm {
 #[macro_export]
 macro_rules! new_xtensa {
     ($bus_type:ty = $bus:expr) => {{
-        let m: Option<&'static mut _> = $crate::xtensa_lx6::singleton!(
+        let m: Option<&'static mut _> = $crate::xtensa_lx::singleton!(
             : $crate::BusManagerXtensa<$bus_type> =
                 $crate::BusManagerXtensa::new($bus)
         );


### PR DESCRIPTION
the Xtensa crate changed the name of the class from xtensa_lx6 to xtensa_lx at some point, this PR updates that for shared_bus. Successfully compiles for a target of esp32.