### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ nb = "1.0.0"
 once_cell = { version = "1.4.0", optional = true }
 cortex-m = { version = "0.7.7", optional = true }
 xtensa-lx = { version = "0.8.0", optional = true, features = ["spin"] }
-spin = { version = "0.9.2", optional = true }
+spin = { version = "0.9.8", optional = true }
 atomic-polyfill = { version = "1.0.1", optional = true }
 
 embedded-hal-alpha = { package = "embedded-hal", version = "=1.0.0-alpha.9", optional = true }


### PR DESCRIPTION
Updates dependency to the patch version of 0.9.8

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0031.html)